### PR TITLE
Added HTTP Authentication

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,29 +9,29 @@ module.exports = {
 	// radius secret
 	secret: 'testing123',
 
-	certificate: {
-		cert: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.crt')),
-		key: [
-			{
-				pem: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.key')),
-				passphrase: 'whatever2020',
-			},
-		],
-		// sessionTimeout: 3600,
-		// sesionIdContext: 'meiasdfkljasdft!',
-		// ticketKeys: Buffer.from('123456789012345678901234567890123456789012345678'),
-	},
+	// certificate: {
+	// 	cert: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.crt')),
+	// 	key: [
+	// 		{
+	// 			pem: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.key')),
+	// 			passphrase: 'whatever2020',
+	// 		},
+	// 	],
+	// 	// sessionTimeout: 3600,
+	// 	// sesionIdContext: 'meiasdfkljasdft!',
+	// 	// ticketKeys: Buffer.from('123456789012345678901234567890123456789012345678'),
+	// },
 
-	// GoogleLDAPAuth (optimized for google auth)
-	authentication: 'GoogleLDAPAuth',
-	authenticationOptions: {
-		base: 'dc=hokify,dc=com',
-		// get your keys from http://admin.google.com/ -> Apps -> LDAP -> Client
-		tls: {
-			keyFile: 'ldap.gsuite.key',
-			certFile: 'ldap.gsuite.crt',
-		},
-	},
+	// // GoogleLDAPAuth (optimized for google auth)
+	// authentication: 'GoogleLDAPAuth',
+	// authenticationOptions: {
+	// 	base: 'dc=hokify,dc=com',
+	// 	// get your keys from http://admin.google.com/ -> Apps -> LDAP -> Client
+	// 	tls: {
+	// 		keyFile: 'ldap.gsuite.key',
+	// 		certFile: 'ldap.gsuite.crt',
+	// 	},
+	// },
 
 	/** LDAP AUTH 
 	authentication: 'LDAPAuth',
@@ -67,4 +67,11 @@ module.exports = {
 		validHosts: ['gmail.com']
 	}
 	 */
+
+	/** HTTP AUTH 
+	authentication: 'HTTPAuth',
+	authenticationOptions: {
+		url: 'https://my-website.com/api/backend-login'
+	}
+	*/
 };

--- a/config.js
+++ b/config.js
@@ -9,29 +9,29 @@ module.exports = {
 	// radius secret
 	secret: 'testing123',
 
-	// certificate: {
-	// 	cert: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.crt')),
-	// 	key: [
-	// 		{
-	// 			pem: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.key')),
-	// 			passphrase: 'whatever2020',
-	// 		},
-	// 	],
-	// 	// sessionTimeout: 3600,
-	// 	// sesionIdContext: 'meiasdfkljasdft!',
-	// 	// ticketKeys: Buffer.from('123456789012345678901234567890123456789012345678'),
-	// },
+	certificate: {
+		cert: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.crt')),
+		key: [
+			{
+				pem: fs.readFileSync(path.join(SSL_CERT_DIRECTORY, '/server.key')),
+				passphrase: 'whatever2020',
+			},
+		],
+		// sessionTimeout: 3600,
+		// sesionIdContext: 'meiasdfkljasdft!',
+		// ticketKeys: Buffer.from('123456789012345678901234567890123456789012345678'),
+	},
 
-	// // GoogleLDAPAuth (optimized for google auth)
-	// authentication: 'GoogleLDAPAuth',
-	// authenticationOptions: {
-	// 	base: 'dc=hokify,dc=com',
-	// 	// get your keys from http://admin.google.com/ -> Apps -> LDAP -> Client
-	// 	tls: {
-	// 		keyFile: 'ldap.gsuite.key',
-	// 		certFile: 'ldap.gsuite.crt',
-	// 	},
-	// },
+	// GoogleLDAPAuth (optimized for google auth)
+	authentication: 'GoogleLDAPAuth',
+	authenticationOptions: {
+		base: 'dc=hokify,dc=com',
+		// get your keys from http://admin.google.com/ -> Apps -> LDAP -> Client
+		tls: {
+			keyFile: 'ldap.gsuite.key',
+			certFile: 'ldap.gsuite.crt',
+		},
+	},
 
 	/** LDAP AUTH 
 	authentication: 'LDAPAuth',
@@ -67,7 +67,7 @@ module.exports = {
 		validHosts: ['gmail.com']
 	}
 	 */
-
+	 
 	/** HTTP AUTH 
 	authentication: 'HTTPAuth',
 	authenticationOptions: {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	"main": "dist/app.js",
 	"dependencies": {
 		"@hokify/node-ts-cache": "^5.4.1",
+		"axios": "^0.21.1",
 		"debug": "^4.3.1",
 		"imap-simple": "^5.0.0",
 		"ldapauth-fork": "^5.0.1",

--- a/src/auth/HTTPAuth.ts
+++ b/src/auth/HTTPAuth.ts
@@ -13,24 +13,32 @@ export class HTTPAuth implements IAuthentication {
 	}
 
 	async authenticate(username: string, password: string) {
-
 		let success = false;
 		try {
-			
 			await axios
-			  .post(this.url, {
-			    username: username,
-			    password: password
-			  })
-			  .then(res => {
-				    console.log("Code: " + res.status)
-				    if (res.status == 200) {
-				    	success = true;
-				    	console.log("Return code 200, authentication successful.");
-				    }
-			  });
+				.post(
+					this.url,
+					{
+						username,
+						password,
+					},
+					{
+						validateStatus(status) {
+							return status >= 200 && status < 500;
+						},
+					}
+				)
+				.then((res) => {
+					console.log(`Code: ${res.status}`);
+					if (res.status === 200) {
+						success = true;
+						console.log('Return code 200, HTTP authentication successful');
+					} else {
+						console.log('HTTP authentication failed');
+					}
+				});
 		} catch (err) {
-			console.error('HTTP auth failed');
+			console.error('HTTP response error');
 		}
 		return success;
 	}

--- a/src/auth/HTTPAuth.ts
+++ b/src/auth/HTTPAuth.ts
@@ -1,0 +1,37 @@
+import axios from 'axios';
+import { IAuthentication } from '../types/Authentication';
+
+interface IHTTPAuthOptions {
+	url: string;
+}
+
+export class HTTPAuth implements IAuthentication {
+	private url: string;
+
+	constructor(config: IHTTPAuthOptions) {
+		this.url = config.url;
+	}
+
+	async authenticate(username: string, password: string) {
+
+		let success = false;
+		try {
+			
+			await axios
+			  .post(this.url, {
+			    username: username,
+			    password: password
+			  })
+			  .then(res => {
+				    console.log("Code: " + res.status)
+				    if (res.status == 200) {
+				    	success = true;
+				    	console.log("Return code 200, authentication successful.");
+				    }
+			  });
+		} catch (err) {
+			console.error('HTTP auth failed');
+		}
+		return success;
+	}
+}


### PR DESCRIPTION
Added support for simple HTTP based authentication.

`{
	authentication: 'HTTPAuth',
	authenticationOptions: {
		url: 'https://my-website.com/api/backend-login'
	}
}`

It will send a JSON POST request to specified URL and expecting status code 200 in order to be passed as successful authentication.