### PR TITLE
refactor: revert to common js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 .DS_Store
+/.idea/
 
 # build files
 dist

--- a/bin/radius-server.js
+++ b/bin/radius-server.js
@@ -2,4 +2,4 @@
 
 'use strict';
 
-await import('../dist/app.js');
+await import('../dist/app');

--- a/config.js
+++ b/config.js
@@ -1,14 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const fs = require('fs');
+const path = require('path');
 
 const SSL_CERT_DIRECTORY = path.join(__dirname, './ssl/cert');
 
-export default {
+module.exports = {
 	port: 1812,
 	// radius secret
 	secret: 'testing123',
@@ -37,7 +33,7 @@ export default {
 		},
 	},
 
-	/** LDAP AUTH 
+	/** LDAP AUTH
 	authentication: 'LDAPAuth',
 	authenticationOptions: {
 		url: 'ldaps://ldap.google.com',
@@ -50,10 +46,10 @@ export default {
 			rejectUnauthorized: false,
 			requestCert: false,
 		},
-	}, 
+	},
 	 */
 
-	/** static auth 
+	/** static auth
 	authentication: 'StaticAuth',
 	authenticationOptions: {
 		validCredentials: [
@@ -68,7 +64,7 @@ export default {
 	vlan: 400,
 	 */
 
-	/** SMTP AUTH 
+	/** SMTP AUTH
 	authentication: 'IMAPAuth',
 	authenticationOptions: {
 		host: 'smtp.gmail.com',
@@ -78,7 +74,7 @@ export default {
 	}
 	 */
 
-	/** HTTP AUTH 
+	/** HTTP AUTH
 	authentication: 'HTTPAuth',
 	authenticationOptions: {
 		url: 'https://my-website.com/api/backend-login'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "2.1.1",
 			"license": "GPL-3.0",
 			"dependencies": {
-				"@hokify/node-ts-cache": "^6.0.0",
+				"@hokify/node-ts-cache": "^5.6.0",
 				"imap-simple": "^5.1.0",
 				"ldapauth-fork": "^5.0.2",
 				"ldapjs": "^2.3.2",
 				"native-duplexpair": "^1.0.0",
 				"node-cache": "^5.1.2",
-				"node-fetch": "^3.2.3",
+				"node-fetch": "^2.6.7",
 				"radius": "~1.1.4",
 				"smtp-client": "^0.4.0",
 				"yargs": "~17.4.0"
@@ -242,12 +242,9 @@
 			}
 		},
 		"node_modules/@hokify/node-ts-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@hokify/node-ts-cache/-/node-ts-cache-6.0.0.tgz",
-			"integrity": "sha512-9n4hZmEEfVYa7ZTr/maMSqIGrcF0xzrJd4ljPr/FuJwUBAHP2NFoi4q1bKgzVswUL/WUHnUf4Y7eqfa2n/7B9g==",
-			"engines": {
-				"node": ">=16.0.0"
-			}
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@hokify/node-ts-cache/-/node-ts-cache-5.6.0.tgz",
+			"integrity": "sha512-VdjeFjLAT9gGrRlzjZsMeY9ZWJyfz8y8ODeZsUdSnDdwxqb0keZNAtS3PMswBzSECBfNV1RT+NGiC8j6P1Cv6w=="
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.9.5",
@@ -1591,14 +1588,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/data-uri-to-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-			"engines": {
-				"node": ">= 12"
-			}
-		},
 		"node_modules/dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -1910,9 +1899,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+			"integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.2.1",
@@ -2591,28 +2580,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"node_modules/fetch-blob": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"dependencies": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			},
-			"engines": {
-				"node": "^12.20 || >= 14.13"
-			}
-		},
 		"node_modules/figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -2700,17 +2667,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
-		},
-		"node_modules/formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dependencies": {
-				"fetch-blob": "^3.1.2"
-			},
-			"engines": {
-				"node": ">=12.20.0"
-			}
 		},
 		"node_modules/fs-access": {
 			"version": "1.0.1",
@@ -4246,39 +4202,23 @@
 				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/jimmywarting"
-				},
-				{
-					"type": "github",
-					"url": "https://paypal.me/jimmywarting"
-				}
-			],
-			"engines": {
-				"node": ">=10.5.0"
-			}
-		},
 		"node_modules/node-fetch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-			"integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dependencies": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
+				"whatwg-url": "^5.0.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": "4.x || >=6.0.0"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/node-fetch"
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/nodeify": {
@@ -5661,6 +5601,11 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -5945,12 +5890,18 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
-		"node_modules/web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-			"engines": {
-				"node": ">= 8"
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -6312,9 +6263,9 @@
 			}
 		},
 		"@hokify/node-ts-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@hokify/node-ts-cache/-/node-ts-cache-6.0.0.tgz",
-			"integrity": "sha512-9n4hZmEEfVYa7ZTr/maMSqIGrcF0xzrJd4ljPr/FuJwUBAHP2NFoi4q1bKgzVswUL/WUHnUf4Y7eqfa2n/7B9g=="
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@hokify/node-ts-cache/-/node-ts-cache-5.6.0.tgz",
+			"integrity": "sha512-VdjeFjLAT9gGrRlzjZsMeY9ZWJyfz8y8ODeZsUdSnDdwxqb0keZNAtS3PMswBzSECBfNV1RT+NGiC8j6P1Cv6w=="
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.9.5",
@@ -7334,11 +7285,6 @@
 			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
 			"dev": true
 		},
-		"data-uri-to-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-		},
 		"dateformat": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -7568,9 +7514,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.12.0.tgz",
-			"integrity": "sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==",
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.13.0.tgz",
+			"integrity": "sha512-D+Xei61eInqauAyTJ6C0q6x9mx7kTUC1KZ0m0LSEexR0V+e94K12LmWX076ZIsldwfQ2RONdaJe0re0TRGQbRQ==",
 			"dev": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.2.1",
@@ -8085,15 +8031,6 @@
 				"reusify": "^1.0.4"
 			}
 		},
-		"fetch-blob": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-			"integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-			"requires": {
-				"node-domexception": "^1.0.0",
-				"web-streams-polyfill": "^3.0.3"
-			}
-		},
 		"figures": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -8159,14 +8096,6 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
 			"integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
 			"dev": true
-		},
-		"formdata-polyfill": {
-			"version": "4.0.10",
-			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"requires": {
-				"fetch-blob": "^3.1.2"
-			}
 		},
 		"fs-access": {
 			"version": "1.0.1",
@@ -9314,19 +9243,12 @@
 				"clone": "2.x"
 			}
 		},
-		"node-domexception": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-		},
 		"node-fetch": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-			"integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"requires": {
-				"data-uri-to-buffer": "^4.0.0",
-				"fetch-blob": "^3.1.4",
-				"formdata-polyfill": "^4.0.10"
+				"whatwg-url": "^5.0.0"
 			}
 		},
 		"nodeify": {
@@ -10356,6 +10278,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
 		"trim-newlines": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -10574,10 +10501,19 @@
 				}
 			}
 		},
-		"web-streams-polyfill": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,15 +30,14 @@
 	"author": "Simon Tretter <simon.tretter@hokify.com>",
 	"preferGlobal": true,
 	"main": "dist/index.js",
-	"type": "module",
 	"dependencies": {
-		"@hokify/node-ts-cache": "^6.0.0",
+		"@hokify/node-ts-cache": "^5.6.0",
 		"imap-simple": "^5.1.0",
 		"ldapauth-fork": "^5.0.2",
 		"ldapjs": "^2.3.2",
 		"native-duplexpair": "^1.0.0",
 		"node-cache": "^5.1.2",
-		"node-fetch": "^3.2.3",
+		"node-fetch": "^2.6.7",
 		"radius": "~1.1.4",
 		"smtp-client": "^0.4.0",
 		"yargs": "~17.4.0"

--- a/src/auth/GoogleLDAPAuth.ts
+++ b/src/auth/GoogleLDAPAuth.ts
@@ -1,6 +1,6 @@
 import ldapjs, { ClientOptions } from 'ldapjs';
-import * as tls from 'tls';
-import * as fs from 'fs';
+import tls from 'tls';
+import fs from 'fs';
 import { IAuthentication } from '../interfaces/Authentication';
 import { ILogger } from '../interfaces/Logger';
 

--- a/src/auth/IMAPAuth.ts
+++ b/src/auth/IMAPAuth.ts
@@ -1,4 +1,4 @@
-import * as imaps from 'imap-simple';
+import imaps from 'imap-simple';
 import { IAuthentication } from '../interfaces/Authentication';
 import { ILogger } from '../interfaces/Logger';
 

--- a/src/auth/LDAPAuth.ts
+++ b/src/auth/LDAPAuth.ts
@@ -1,5 +1,5 @@
-import * as LdapAuth from 'ldapauth-fork';
-import * as fs from 'fs';
+import LdapAuth from 'ldapauth-fork';
+import fs from 'fs';
 import { IAuthentication } from '../interfaces/Authentication';
 import { ILogger } from '../interfaces/Logger';
 

--- a/src/radius/PacketHandler.ts
+++ b/src/radius/PacketHandler.ts
@@ -1,13 +1,13 @@
-import * as tls from 'tls';
+import tls from 'tls';
 
-import { IPacket, IPacketHandler, IPacketHandlerResult } from '../interfaces/PacketHandler.js';
-import { IAuthentication } from '../interfaces/Authentication.js';
-import { EAPPacketHandler } from './handler/EAPPacketHandler.js';
-import { EAPTTLS } from './handler/eap/eapMethods/EAP-TTLS.js';
-import { EAPGTC } from './handler/eap/eapMethods/EAP-GTC.js';
-import { EAPMD5 } from './handler/eap/eapMethods/EAP-MD5.js';
-import { UserPasswordPacketHandler } from './handler/UserPasswordPacketHandler.js';
-import { ILogger } from '../interfaces/Logger.js';
+import { IPacket, IPacketHandler, IPacketHandlerResult } from '../interfaces/PacketHandler';
+import { IAuthentication } from '../interfaces/Authentication';
+import { EAPPacketHandler } from './handler/EAPPacketHandler';
+import { EAPTTLS } from './handler/eap/eapMethods/EAP-TTLS';
+import { EAPGTC } from './handler/eap/eapMethods/EAP-GTC';
+import { EAPMD5 } from './handler/eap/eapMethods/EAP-MD5';
+import { UserPasswordPacketHandler } from './handler/UserPasswordPacketHandler';
+import { ILogger } from '../interfaces/Logger';
 
 export class PacketHandler implements IPacketHandler {
 	packetHandlers: IPacketHandler[] = [];

--- a/src/radius/RadiusServer.ts
+++ b/src/radius/RadiusServer.ts
@@ -1,12 +1,12 @@
-import * as radius from 'radius';
+import radius from 'radius';
 import { EventEmitter } from 'events';
-import { IPacketHandlerResult, PacketResponseCode } from '../interfaces/PacketHandler.js';
+import { IPacketHandlerResult, PacketResponseCode } from '../interfaces/PacketHandler';
 
-import { PacketHandler } from './PacketHandler.js';
-import { UDPServer } from '../server/UDPServer.js';
-import { startTLSServer } from '../tls/crypt.js';
-import { RadiusServerOptions } from '../interfaces/RadiusServerOptions.js';
-import { ConsoleLogger, LogLevel } from '../logger/ConsoleLogger.js';
+import { PacketHandler } from './PacketHandler';
+import { UDPServer } from '../server/UDPServer';
+import { startTLSServer } from '../tls/crypt';
+import { RadiusServerOptions } from '../interfaces/RadiusServerOptions';
+import { ConsoleLogger, LogLevel } from '../logger/ConsoleLogger';
 
 function hasLogger(options): options is { logger: ConsoleLogger } {
 	return !!options.logger;

--- a/src/radius/handler/EAPPacketHandler.ts
+++ b/src/radius/handler/EAPPacketHandler.ts
@@ -1,11 +1,11 @@
 // https://tools.ietf.org/html/rfc3748#section-4.1
 
 import NodeCache from 'node-cache';
-import { makeid } from '../../helpers.js';
-import { IPacket, IPacketHandler, IPacketHandlerResult } from '../../interfaces/PacketHandler.js';
-import { IEAPMethod } from '../../interfaces/EAPMethod.js';
-import { buildEAPResponse, decodeEAPHeader } from './eap/EAPHelper.js';
-import { ILogger } from '../../interfaces/Logger.js';
+import { makeid } from '../../helpers';
+import { IPacket, IPacketHandler, IPacketHandlerResult } from '../../interfaces/PacketHandler';
+import { IEAPMethod } from '../../interfaces/EAPMethod';
+import { buildEAPResponse, decodeEAPHeader } from './eap/EAPHelper';
+import { ILogger } from '../../interfaces/Logger';
 
 export class EAPPacketHandler implements IPacketHandler {
 	private identities = new NodeCache({ useClones: false, stdTTL: 60 }); // queue data maximum for 60 seconds

--- a/src/radius/handler/UserPasswordPacketHandler.ts
+++ b/src/radius/handler/UserPasswordPacketHandler.ts
@@ -1,11 +1,11 @@
-import { IAuthentication } from '../../interfaces/Authentication.js';
+import { IAuthentication } from '../../interfaces/Authentication';
 import {
 	IPacket,
 	IPacketHandler,
 	IPacketHandlerResult,
 	PacketResponseCode,
-} from '../../interfaces/PacketHandler.js';
-import { ILogger } from '../../interfaces/Logger.js';
+} from '../../interfaces/PacketHandler';
+import { ILogger } from '../../interfaces/Logger';
 
 export class UserPasswordPacketHandler implements IPacketHandler {
 	constructor(private authentication: IAuthentication, private logger: ILogger) {}

--- a/src/radius/handler/eap/EAPHelper.ts
+++ b/src/radius/handler/eap/EAPHelper.ts
@@ -1,4 +1,4 @@
-import { IPacketHandlerResult, PacketResponseCode } from '../../../interfaces/PacketHandler.js';
+import { IPacketHandlerResult, PacketResponseCode } from '../../../interfaces/PacketHandler';
 
 export function buildEAP(identifier: number, msgType: number, data?: Buffer) {
 	/** build a package according to this:

--- a/src/radius/handler/eap/eapMethods/EAP-GTC.ts
+++ b/src/radius/handler/eap/eapMethods/EAP-GTC.ts
@@ -1,11 +1,11 @@
 // https://tools.ietf.org/html/rfc5281 TTLS v0
 // https://tools.ietf.org/html/draft-funk-eap-ttls-v1-00 TTLS v1 (not implemented)
 /* eslint-disable no-bitwise */
-import { IPacketHandlerResult, PacketResponseCode } from '../../../../interfaces/PacketHandler.js';
-import { IEAPMethod } from '../../../../interfaces/EAPMethod.js';
-import { IAuthentication } from '../../../../interfaces/Authentication.js';
-import { buildEAPResponse, decodeEAPHeader } from '../EAPHelper.js';
-import { ILogger } from '../../../../interfaces/Logger.js';
+import { IPacketHandlerResult, PacketResponseCode } from '../../../../interfaces/PacketHandler';
+import { IEAPMethod } from '../../../../interfaces/EAPMethod';
+import { IAuthentication } from '../../../../interfaces/Authentication';
+import { buildEAPResponse, decodeEAPHeader } from '../EAPHelper';
+import { ILogger } from '../../../../interfaces/Logger';
 
 export class EAPGTC implements IEAPMethod {
 	getEAPType(): number {

--- a/src/radius/handler/eap/eapMethods/EAP-MD5.ts
+++ b/src/radius/handler/eap/eapMethods/EAP-MD5.ts
@@ -2,10 +2,10 @@
 // https://tools.ietf.org/html/draft-funk-eap-ttls-v1-00 TTLS v1 (not implemented)
 /* eslint-disable no-bitwise */
 import { RadiusPacket } from 'radius';
-import { IPacketHandlerResult } from '../../../../interfaces/PacketHandler.js';
-import { IEAPMethod } from '../../../../interfaces/EAPMethod.js';
-import { IAuthentication } from '../../../../interfaces/Authentication.js';
-import { ILogger } from '../../../../interfaces/Logger.js';
+import { IPacketHandlerResult } from '../../../../interfaces/PacketHandler';
+import { IEAPMethod } from '../../../../interfaces/EAPMethod';
+import { IAuthentication } from '../../../../interfaces/Authentication';
+import { ILogger } from '../../../../interfaces/Logger';
 
 export class EAPMD5 implements IEAPMethod {
 	getEAPType(): number {

--- a/src/radius/handler/eap/eapMethods/EAP-TTLS.ts
+++ b/src/radius/handler/eap/eapMethods/EAP-TTLS.ts
@@ -1,23 +1,23 @@
 // https://tools.ietf.org/html/rfc5281 TTLS v0
 // https://tools.ietf.org/html/draft-funk-eap-ttls-v1-00 TTLS v1 (not implemented)
 /* eslint-disable no-bitwise */
-import * as tls from 'tls';
+import tls from 'tls';
 import NodeCache from 'node-cache';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-import * as radius from 'radius';
+import radius from 'radius';
 
-import { encodeTunnelPW, ITLSServer, startTLSServer } from '../../../../tls/crypt.js';
+import { encodeTunnelPW, ITLSServer, startTLSServer } from '../../../../tls/crypt';
 import {
 	IPacket,
 	IPacketAttributes,
 	IPacketHandler,
 	IPacketHandlerResult,
 	PacketResponseCode,
-} from '../../../../interfaces/PacketHandler.js';
-import { MAX_RADIUS_ATTRIBUTE_SIZE, newDeferredPromise } from '../../../../helpers.js';
-import { IEAPMethod } from '../../../../interfaces/EAPMethod.js';
-import { IAuthentication } from '../../../../interfaces/Authentication.js';
-import { ILogger } from '../../../../interfaces/Logger.js';
+} from '../../../../interfaces/PacketHandler';
+import { MAX_RADIUS_ATTRIBUTE_SIZE, newDeferredPromise } from '../../../../helpers';
+import { IEAPMethod } from '../../../../interfaces/EAPMethod';
+import { IAuthentication } from '../../../../interfaces/Authentication';
+import { ILogger } from '../../../../interfaces/Logger';
 
 function tlsHasExportKeyingMaterial(tlsSocket): tlsSocket is {
 	exportKeyingMaterial: (length: number, label: string, context?: Buffer) => Buffer;

--- a/src/server/UDPServer.ts
+++ b/src/server/UDPServer.ts
@@ -1,17 +1,15 @@
-import * as dgram from 'dgram';
-import { SocketType } from 'dgram';
-import * as events from 'events';
+import dgram, { Socket, SocketType } from 'dgram';
 import { EventEmitter } from 'events';
-import { newDeferredPromise } from '../helpers.js';
-import type { IServer } from '../interfaces/Server.js';
-import type { ILogger } from '../interfaces/Logger.js';
+import { newDeferredPromise } from '../helpers';
+import type { IServer } from '../interfaces/Server';
+import type { ILogger } from '../interfaces/Logger';
 
-export class UDPServer extends events.EventEmitter implements IServer {
+export class UDPServer extends EventEmitter implements IServer {
 	static MAX_RETRIES = 3;
 
 	private timeout: { [key: string]: NodeJS.Timeout } = {};
 
-	private server: dgram.Socket;
+	private server: Socket;
 
 	constructor(
 		private port: number,

--- a/src/tls/crypt.ts
+++ b/src/tls/crypt.ts
@@ -1,11 +1,10 @@
-import * as events from 'events';
-import * as tls from 'tls';
-import { createSecureContext } from 'tls';
-import * as crypto from 'crypto';
+import events from 'events';
+import tls, { createSecureContext } from 'tls';
+import crypto from 'crypto';
 import DuplexPair from 'native-duplexpair';
 import NodeCache from 'node-cache';
-import { ILogger } from '../interfaces/Logger.js';
-// import * as constants from 'constants';
+import { ILogger } from '../interfaces/Logger';
+// import constants from 'constants';
 
 export interface ITLSServer {
 	events: events.EventEmitter;
@@ -176,7 +175,7 @@ export function encodeTunnelPW(key: Buffer, authenticator: Buffer, secret: strin
    Intermediate values b(1), b(2)...c(i) are required.  Encryption
    is performed in the following manner ('+' indicates
    concatenation):
-   
+
       Zorn                         Informational                     [Page 21]
 
    RFC 2548      Microsoft Vendor-specific RADIUS Attributes     March 1999

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
 		"sourceMap": true,
 		"isolatedModules": false,
 		"esModuleInterop": true,
-		"declaration": true
+		"declaration": true,
+		"skipLibCheck": true,
 	},
 	"exclude": ["node_modules", "**/__tests__"],
 	"include": ["./src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"rootDir": "./src",
 
 		// target settings for node js
-		"module": "ES2020",
+		"module": "CommonJS",
 		"target": "ES2021",
 		"lib": ["ES2021", "dom"],
 
@@ -23,6 +23,7 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"isolatedModules": false,
+		"esModuleInterop": true,
 		"declaration": true
 	},
 	"exclude": ["node_modules", "**/__tests__"],


### PR DESCRIPTION
## Motivation:
CJS is still dominant in the Node echosystem and is still the default.
Since there are no benefits to ESM in this project that i can think i don't think it's a good idea to switch to ESM (yet).
ESM makes it difficult (and i belive even impossible) to use this module in CJS projects.
Making this ESM only makes it inpossible (as far as i know) to use this in an NestJS project.
