### PR TITLE
Add UDPServer.stop method to close server

### DIFF
--- a/src/server/UDPServer.ts
+++ b/src/server/UDPServer.ts
@@ -80,6 +80,16 @@ export class UDPServer extends events.EventEmitter implements IServer {
 		return startServer.promise;
 	}
 
+	async stop(): Promise<void> {
+		const stopServer = newDeferredPromise();
+		this.server.close(() => {
+			this.logger.log('UDPServer', `radius server closed`);
+			stopServer.resolve();
+		});
+
+		return stopServer.promise;
+	}
+
 	private setupListeners() {
 		this.server.on('message', (message, rinfo) => this.emit('message', message, rinfo));
 	}


### PR DESCRIPTION
Currently, there's no way to stop the RADIUS server when it was started programmatically without accessing the private `UDPServer.server` member.

So, add a `stop` method to the `UDPServer` which gracefully closes the server.